### PR TITLE
Fix typo in signature signing formula.

### DIFF
--- a/bip-schnorr.mediawiki
+++ b/bip-schnorr.mediawiki
@@ -137,7 +137,7 @@ To sign:
 * Let ''R = kG''.
 * If ''jacobi(y(R)) &ne; 1'', let ''k = n - k''.
 * Let ''e = int(hash(bytes(x(R)) || bytes(dG) || m)) mod n''.
-* The signature is ''bytes(x(R)) || bytes(k + ex mod n)''.
+* The signature is ''bytes(x(R)) || bytes(k + ed mod n)''.
 
 Note that this is not a ''unique signature'' scheme: while this algorithm will always produce the same signature for a given message and public key, ''k'' (and hence ''R'') may be generated in other ways (such as by a CSPRNG) producing a different, but still valid, signature.
 


### PR DESCRIPTION
In signature signing formula, the secret key "d" was misspelled as "x". Fixed.