### PR TITLE
suggestion: modify modulo so that k'=0 fail never occurs

### DIFF
--- a/bip-schnorr.mediawiki
+++ b/bip-schnorr.mediawiki
@@ -133,7 +133,7 @@ Input:
 * The message ''m'': an array of 32 bytes
 
 To sign ''m'' for public key ''dG'':
-* Let ''k' = 1 + int(hash(bytes(d) || m)) mod (n-1)''<ref>Note that in general, taking the output of a hash function modulo the curve order will produce an unacceptably biased result. However, for the secp256k1 curve, the order is sufficiently close to ''2<sup>256</sup>'' that this bias is not observable (''1 - n / 2<sup>256</sup>'' is around ''1.27 * 2<sup>-128</sup>'').</ref>.
+* Let ''k' = 1 + (int(hash(bytes(d) || m)) mod (n-1))''<ref>Note that in general, taking the output of a hash function modulo the curve order will produce an unacceptably biased result. However, for the secp256k1 curve, the order is sufficiently close to ''2<sup>256</sup>'' that this bias is not observable (''1 - n / 2<sup>256</sup>'' is around ''1.27 * 2<sup>-128</sup>'').</ref>.
 * Let ''R = k'G''.
 * Let ''k = k' '' if ''jacobi(y(R)) = 1'', otherwise let ''k = n - k' ''.
 * Let ''e = int(hash(bytes(x(R)) || bytes(dG) || m)) mod n''.

--- a/bip-schnorr.mediawiki
+++ b/bip-schnorr.mediawiki
@@ -133,8 +133,7 @@ Input:
 * The message ''m'': an array of 32 bytes
 
 To sign ''m'' for public key ''dG'':
-* Let ''k' = int(hash(bytes(d) || m)) mod n''<ref>Note that in general, taking the output of a hash function modulo the curve order will produce an unacceptably biased result. However, for the secp256k1 curve, the order is sufficiently close to ''2<sup>256</sup>'' that this bias is not observable (''1 - n / 2<sup>256</sup>'' is around ''1.27 * 2<sup>-128</sup>'').</ref>.
-* Fail if ''k' = 0''
+* Let ''k' = 1 + int(hash(bytes(d) || m)) mod (n-1)''<ref>Note that in general, taking the output of a hash function modulo the curve order will produce an unacceptably biased result. However, for the secp256k1 curve, the order is sufficiently close to ''2<sup>256</sup>'' that this bias is not observable (''1 - n / 2<sup>256</sup>'' is around ''1.27 * 2<sup>-128</sup>'').</ref>.
 * Let ''R = k'G''.
 * Let ''k = k' '' if ''jacobi(y(R)) = 1'', otherwise let ''k = n - k' ''.
 * Let ''e = int(hash(bytes(x(R)) || bytes(dG) || m)) mod n''.


### PR DESCRIPTION
In order to cleanly map a large integer into the `1...n-1` range, we can take modulo `n-1` and add one, instead of taking modulo `n` and failing on zero.