### PR TITLE
Use a hash to seed the CSPRNG for batch verification

### DIFF
--- a/bip-schnorr.mediawiki
+++ b/bip-schnorr.mediawiki
@@ -112,7 +112,7 @@ Input:
 * The public keys ''P<sub>1...u</sub>'': ''u'' points
 * The messages ''m<sub>1...u</sub>'': ''u'' 32 byte arrays.
 * The signatures ''sig<sub>1...u</sub>'': ''u'' 64 byte arrays.
-* Random numbers ''a<sub>2...u</sub>'' in the range ''1...n-1'': ''u-1'' integers. These can either be generated deterministically using a [https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator CSPRNG] seeded by all the other inputs, or be randomly generated independently for each batch of verifications.
+* Random numbers ''a<sub>2...u</sub>'' in the range ''1...n-1'': ''u-1'' integers. These can either be generated deterministically using a [https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator CSPRNG] seeded by a cryptographic hash (e.g., SHA256) of all the other inputs, or be randomly generated independently for each batch of verifications.
 
 All provided signatures are valid if and only if the algorithm below does not fail.
 * For ''i = 1 .. u'':


### PR DESCRIPTION
A PRG alone is not sufficient. We need a hash function, and then I think this can be proven secure in the ROM (it forces the attacker to choose the other inputs first, in a Fiat-Shamir style).

One thing to keep in mind:
If batch verification is deterministic, one problem is that different implementations could use different ways to generate the random numbers, and arrive at different results. The probability that this happens is negligible however (unless the hash function is terribly broken).