### PR TITLE
Clarify random number generation in batch verification

### DIFF
--- a/bip-schnorr.mediawiki
+++ b/bip-schnorr.mediawiki
@@ -1,3 +1,13 @@
+<pre>
+  BIP: ?
+  Title: Schnorr Signatures
+  Author: Pieter Wuille <pieter.wuille@gmail.com>
+  Status: Draft
+  Type: Informational
+  License: BSD-2-Clause
+  Post-History: 2018-07-06: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-July/016203.html [bitcoin-dev] Schnorr signatures BIP
+</pre>
+
 ==Introduction==
 
 ===Abstract===

--- a/bip-schnorr.mediawiki
+++ b/bip-schnorr.mediawiki
@@ -140,6 +140,9 @@ To sign ''m'' for public key ''dG'':
 * Let ''e = int(hash(bytes(x(R)) || bytes(dG) || m)) mod n''.
 * The signature is ''bytes(x(R)) || bytes(k + ed mod n)''.
 
+'''Above deterministic derivation of ''R'' is designed specifically for this signing algorithm and may not be secure when used in other signature schemes.'''
+For example, using the same derivation in the MuSig multi-signature scheme leaks the secret key (see the [https://eprint.iacr.org/2018/068 MuSig paper] for details).
+
 Note that this is not a ''unique signature'' scheme: while this algorithm will always produce the same signature for a given message and public key, ''k'' (and hence ''R'') may be generated in other ways (such as by a CSPRNG) producing a different, but still valid, signature.
 
 === Optimizations ===

--- a/bip-schnorr.mediawiki
+++ b/bip-schnorr.mediawiki
@@ -124,7 +124,7 @@ Input:
 * The signatures ''sig<sub>1..u</sub>'': ''u'' 64-byte arrays
 
 All provided signatures are valid with overwhelming probability if and only if the algorithm below does not fail.
-* Generate ''u-1'' random integers ''a<sub>2...u</sub>'' in the range ''1...n-1''. These can either be generated deterministically using a [https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator CSPRNG] seeded by a cryptographic hash (e.g., SHA256) of all inputs of the algorithm, or be randomly generated independently for each run of the batch verification algorithm.
+* Generate ''u-1'' random integers ''a<sub>2...u</sub>'' in the range ''1...n-1''. They are generated deterministically using a [https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator CSPRNG] seeded by a cryptographic hash of all inputs of the algorithm, i.e. ''seed = seed_hash(pk<sub>1</sub>..pk<sub>u</sub> || m<sub>1</sub>..m<sub>u</sub> || sig<sub>1</sub>..sig<sub>u</sub> )''. A safe choice is to instantiate ''seed_hash'' with SHA256 and use [https://tools.ietf.org/html/rfc8439 ChaCha20] with key ''seed'' as a CSPRNG to generate 256-bit integers, skipping integers not in the range ''1...n-1''.
 * For ''i = 1 .. u'':
 ** Let ''P<sub>i</sub> = point(pk<sub>i</sub>)''; fail if ''point(pk<sub>i</sub>)'' fails.
 ** Let ''r = int(sig<sub>i</sub>[0:32])''; fail if ''r &ge; p''.


### PR DESCRIPTION
As per @real-or-random's suggestion:

1. Specifically state the inputs of seed derivation
2. Remove note that these numbers can be generated "randomly" because it seems much more robust to use a CSPRNG seeded by the inputs instead of system randomness (which can be predictable in VMs, or low entropy)...
3. Mention libsecp implementation as an example (and specifically mention chacha20)