### PR TITLE
taproot_output_script: first returned byte should be OP_1 (0x51)

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -203,7 +203,7 @@ def taproot_output_script(internal_pubkey, script_tree):
     t = tagged_hash("TapTweak", internal_pubkey.get_bytes() + h)
     assert int.from_bytes(t, 'big') < SECP256K1_ORDER
     output_pubkey = internal_pubkey.tweak_add(t).get_bytes()
-    return bytes([0x01, 0x21, output_pubkey[0] & 1]) + output_pubkey[1:]
+    return bytes([0x51, 0x21, output_pubkey[0] & 1]) + output_pubkey[1:]
 </source>
 
 The function <code>taproot_output_script</code> returns a byte array with the scriptPubKey. It can be P2SH wrapped if desired (see BIP141).


### PR DESCRIPTION
If we look at

```
def IsPayToTaproot(script):
      return len(script) == 35 and script[0] == OP_1 and script[1] == 33 and script[2] >= 0 and script[2] <= 1
```

(from test_framework/script.py)

First byte is is checked for OP_1. OP_1 is 0x51

But the example code in `taproot_output_script` returns  

`bytes([0x01, 0x21, output_pubkey[0] & 1]) + output_pubkey[1:]`

First byte 0x01, but it should be 0x51