### PR TITLE
alternative verification: no need to check r range

### DIFF
--- a/bip-schnorr.mediawiki
+++ b/bip-schnorr.mediawiki
@@ -119,12 +119,12 @@ Input:
 
 The signature is valid if and only if the algorithm below does not fail.
 * Let ''P = point(pk)''; fail if ''point(pk)'' fails.
-* Let ''r = int(sig[0:32])''; fail if ''r &ge; p''.
+* Let ''sig0 = sig[0:32]''.
 * Let ''s = int(sig[32:64])''; fail if ''s &ge; n''.
-* Let ''e = int(hash(bytes(r) || bytes(P) || m)) mod n''.
+* Let ''e = int(hash(sig0 || bytes(P) || m)) mod n''.
 * Let ''R = sG - eP''.
 * Fail if ''infinite(R)''.
-* Fail if ''jacobi(y(R)) &ne; 1'' or ''x(R) &ne; r''.
+* Fail if ''jacobi(y(R)) &ne; 1'' or ''bytes(x(R)) &ne; sig0''.
 
 ==== Batch Verification ====
 


### PR DESCRIPTION
(not a serious pull request, just an observation for discussion)

I just noticed this while coding up a python-only Schnorr verifier -- the `r` from the signature never actually needs to be converted to an integer, it can stay as a bytes object the whole way through. It's not needed to check the range of `r` since the final step of comparing it against `x(R)` does this implicitly.

This only saves a negligible amount of CPU cycles, of course.