### PR TITLE
Fix point_from_bytes in bip-schnorr reference implementation

### DIFF
--- a/bip-schnorr/reference.py
+++ b/bip-schnorr/reference.py
@@ -34,7 +34,7 @@ def bytes_from_point(P):
     return (b'\x03' if P[1] & 1 else b'\x02') + bytes_from_int(P[0])
 
 def point_from_bytes(b):
-    if b[0] in [b'\x02', b'\x03']:
+    if b[0:1] in [b'\x02', b'\x03']:
         odd = b[0] - 0x02
     else:
         return None


### PR DESCRIPTION
The reference implementation was broken in https://github.com/sipa/bips/pull/37 and results in some tests failing. Apparently when dealing with python3 bytes `b` then `b[0]` returns an int and `b[0:1]` returns bytes.