### PR TITLE
Use key path spend terminology more consistently in taproot/tapscript

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -210,11 +210,11 @@ The function <code>taproot_output_script</code> returns a byte array with the sc
 
 [[File:bip-taproot/tree.png|frame|This diagram shows the hashing structure to obtain the tweak from an internal key ''P'' and a Merkle tree consisting of 5 script leaves. ''A'', ''B'', ''C'' and ''E'' are ''TapLeaf'' hashes similar to ''D'' and ''AB'' is a ''TapBranch'' hash. Note that when ''CDE'' is computed ''E'' is hashed first because ''E'' is less than ''CD''.]]
 
-'''Spending using the internal key''' A Taproot output can be spent with the private key corresponding to the <code>internal_pubkey</code>. To do so, a witness stack consists of a single element: a bip-schnorr signature on the signature hash as defined above, with the private key tweaked by the same <code>t</code> as in the above snippet. In the code below, <code>internal_privkey</code> has a method <code>pubkey_gen</code> that returns a public key according to bip-schnorr and a boolean indicating the quadratic residuosity of the Y coordinate of the underlying point.
+'''Spending using the key path''' A Taproot output can be spent with the private key corresponding to the <code>internal_pubkey</code>. To do so, a witness stack consists of a single element: a bip-schnorr signature on the signature hash as defined above, with the private key tweaked by the same <code>t</code> as in the above snippet. In the code below, <code>internal_privkey</code> has a method <code>pubkey_gen</code> that returns a public key according to bip-schnorr and a boolean indicating the quadratic residuosity of the Y coordinate of the underlying point.
 See the code below:
 
 <source lang="python">
-def taproot_sign_internal_key(script_tree, internal_privkey, hash_type):
+def taproot_sign_key(script_tree, internal_privkey, hash_type):
     internal_pubkey, is_y_qresidue = internal_privkey.pubkey_gen()
     if is_y_qresidue:
         internal_privkey = internal_privkey.negate()


### PR DESCRIPTION
`sign_internal_key` is a always a bit confusing because you actually sign for the output key (but you're using the internal privkey).