### PR TITLE
Fix privkey negation in taproot_sign_key

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -200,10 +200,10 @@ See the code below:
 
 <source lang="python">
 def taproot_sign_key(script_tree, internal_privkey, hash_type):
-    internal_pubkey, is_y_qresidue = internal_privkey.pubkey_gen()
-    if is_y_qresidue:
-        internal_privkey = internal_privkey.negate()
     _, h = taproot_tree_helper(script_tree)
+    internal_pubkey, is_y_qresidue = internal_privkey.pubkey_gen()
+    if not is_y_qresidue:
+        internal_privkey = internal_privkey.negate()
     t = tagged_hash("TapTweak", internal_pubkey.get_bytes() + h)
     output_privkey = internal_privkey.tweak_add(t)
     sig = output_privkey.schnorr_sign(sighash(hash_type))


### PR DESCRIPTION
Also moved `taproot_tree_helper` to the top of the function because that seemed more logical.