### PR TITLE
Removed reference to 0xc1 leaf version.

### DIFF
--- a/bip-tapscript.mediawiki
+++ b/bip-tapscript.mediawiki
@@ -47,7 +47,7 @@ The rules below only apply when validating a transaction input for which all of 
 * The transaction output is a '''segregated witness spend''' (i.e., either the scriptPubKey or BIP16 redeemScript is a witness program as defined in BIP141).
 * It is a '''taproot spend''' as defined in bip-taproot (i.e., the witness version is 1, the witness program is 32 bytes).
 * It is a '''script path spend''' as defined in bip-taproot (i.e., after removing the optional annex from the witness stack, two or more stack elements remain).
-* The leaf version is ''0xc0'' (i.e. the first byte of the last witness element after removing the optional annex is ''0xc0'' or ''0xc1'')<ref>'''How is the ''0xc0'' constant chosen?''' Following the guidelines in bip-taproot, by choosing a value having the two top bits set, tapscript spends are identifiable even without access to the UTXO being spent.</ref>, marking it as a '''tapscript spend'''.
+* The leaf version is ''0xc0'' (i.e. the first byte of the last witness element after removing the optional annex is ''0xc0'')<ref>'''How is the ''0xc0'' constant chosen?''' Following the guidelines in bip-taproot, by choosing a value having the two top bits set, tapscript spends are identifiable even without access to the UTXO being spent.</ref>, marking it as a '''tapscript spend'''.
 
 Validation of such inputs must be equivalent to performing the following steps in the specified order.
 # If the input is invalid due to BIP16, BIP141, or bip-taproot, fail.
@@ -142,4 +142,3 @@ This rule limits worst-case validation costs in tapscript similar to the ''sigop
 ==Acknowledgements==
 
 This document is the result of many discussions and contains contributions by Jonas Nick, Anthony Towns, and others.
-


### PR DESCRIPTION
This seems no longer necessary with the introduction of 32B public keys.