### PR TITLE
annex is bit 0 of spend_type

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -135,7 +135,7 @@ As the message for signature verification, transaction digest is ''hash<sub>TapS
 *** <code>nSequence</code> (4): <code>nSequence</code> of this input.
 ** If the <code>SIGHASH_ANYONECANPAY</code> flag is not set:
 *** <code>input_index</code> (4): index of this input in the transaction input vector. Index of the first input is 0.
-** If the bit-1 of <code>spend_type</code> is set:
+** If bit 0 of <code>spend_type</code> is set:
 *** <code>sha_annex</code> (32): the SHA256 of (compact_size(size of annex) || annex).
 * Data about this output:
 ** If the <code>SIGHASH_SINGLE</code> flag is set:


### PR DESCRIPTION
definition of spend_type calls it bit 0, but sha_annex definition references bit 1