### PR TITLE
taproot/tapscript updates: 32 byte pubKey, 0x02 key_version

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -128,7 +128,7 @@ As the message for signature verification, transaction digest is ''hash<sub>TapS
 ** <code>spend_type</code> (1):
 *** Bit 0 is set if an annex is present (the original witness stack has two or more witness elements, and the first byte of the last element is <code>0x50</code>).
 *** The other bits are unset.
-** <code>scriptPubKey</code> (35): <code>scriptPubKey</code> of the previous output spent by this input, serialized as script inside <code>CTxOut</code>. Its size is always 35 bytes.
+** <code>scriptPubKey</code> (34): <code>scriptPubKey</code> of the previous output spent by this input, serialized as script inside <code>CTxOut</code>. Its size is always 34 bytes.
 ** If the <code>SIGHASH_ANYONECANPAY</code> flag is set:
 *** <code>outpoint</code> (36): the <code>COutPoint</code> of this input (32-byte hash + 4-byte little-endian).
 *** <code>amount</code> (8): value of the previous output spent by this input.
@@ -141,7 +141,7 @@ As the message for signature verification, transaction digest is ''hash<sub>TapS
 ** If the <code>SIGHASH_SINGLE</code> flag is set:
 *** <code>sha_single_output</code> (32): the SHA256 of the corresponding output in <code>CTxOut</code> format.
 
-The total number of bytes hashed is at most ''211''<ref>'''What is the number of bytes hashed for the signature hash?''' The total size of the input to ''hash<sub>TapSighash</sub>'' (excluding the initial 64-byte hash tag) can be computed using the following formula: ''178 - is_anyonecanpay * 52 - is_none * 32 + has_annex * 32''.</ref>.
+The total number of bytes hashed is at most ''209''<ref>'''What is the number of bytes hashed for the signature hash?''' The total size of the input to ''hash<sub>TapSighash</sub>'' (excluding the initial 64-byte hash tag) can be computed using the following formula: ''177 - is_anyonecanpay * 52 - is_none * 32 + has_annex * 32''.</ref>.
 
 In summary, the semantics of the BIP143 sighash types remain unchanged, except the following:
 # The way and order of serialization is changed.<ref>'''Why is the serialization in the transaction digest changed?''' Hashes that go into the digest and the digest itself are now computed with a single SHA256 invocation instead of double SHA256. There is no expected security improvement by doubling SHA256 because this only protects against length-extension attacks against SHA256 which are not a concern for transaction digests because there is no secret data. Therefore doubling SHA256 is a waste of resources. The digest computation now follows a logical order with transaction level data first, then input data and output data. This allows to efficiently cache the transaction part of the digest across different inputs using the SHA256 midstate. Additionally, digest computation avoids unnecessary hashing as opposed to BIP143 digests in which parts may be set zero and before hashing them. Despite that, collisions are made impossible by committing to the length of the data (implicit in <code>hash_type</code> and <code>spend_type</code>) before the variable length data.</ref>

--- a/bip-tapscript.mediawiki
+++ b/bip-tapscript.mediawiki
@@ -111,7 +111,7 @@ The one-byte <code>spend_type</code> has a different value, specifically at bit 
 
 As additional pieces of data, added at the end of the input to the ''hash<sub>TapSighash</sub>'' function:
 * <code>tapleaf_hash</code> (32): the tapleaf hash as defined in bip-taproot
-* <code>key_version</code> (1): a constant value <code>0x00</code> representing the current version of public keys in the tapscript signature opcode execution.
+* <code>key_version</code> (1): a constant value <code>0x02</code> representing the current version of public keys in the tapscript signature opcode execution.
 * <code>codeseparator_position</code> (4): the opcode position of the last executed <code>OP_CODESEPARATOR</code> before the currently executed signature opcode, with the value in little endian (or <code>0xffffffff</code> if none executed). The first opcode in a script has a position of 0. A multi-byte push opcode is counted as one opcode, regardless of the size of data being pushed.
 
 The total number of bytes hashed is at most ''248''<ref>'''What is the number of bytes hashed for the signature hash?''' The total size of the input to ''hash<sub>TapSighash</sub>'' (excluding the initial 64-byte hash tag) can be computed using the following formula: ''215 - is_anyonecanpay * 52 - is_none * 32 + has_annex * 32''.</ref>.


### PR DESCRIPTION
Testing taproot branch at sipa/bitcoin@527ed7d4b230a694ee223a000cd5fd7495a00fcb
I noticed a few details in the BIPs that seem to be off.

In bip-tapscript the `key_version` is specified as `0x00` but in the code it is `0x02` (I'm curious about the rationale for this as well): 
https://github.com/sipa/bitcoin/blob/527ed7d4b230a694ee223a000cd5fd7495a00fcb/src/script/interpreter.cpp#L1447

In bip-taproot, the move to 32-byte public keys (for bip-schnorr) is not reflected in the size of the transaction serialization. The output `scriptPubKey` being spent from will be `34` bytes instead of `35` (program version + length + 32-byte-pubKey). This is somewhat enforced in the test:
https://github.com/sipa/bitcoin/blob/527ed7d4b230a694ee223a000cd5fd7495a00fcb/test/functional/test_framework/script.py#L614

This PR also updates the "max number of bytes hashed", although I think this statement is misleading since there are so many sha256 operations in the digest process up to this point already, and bip-tapscript specifies a second digest algorithm which consumes additional bytes as well.

Anyway, here's proof of the new total without changing the context of the statement. I'm not sure why it was originally `211`, I'm only subtracting one byte here and I'm getting `209`, so maybe there was another off-by-one in a previous update?

```
not SIGHASH_ANYONECANPAY
has annex

simple formula from footnote #15:
  177 (- 0) (- 0) + 32 = 209

verbose:
  1 epoch
  1 hash_type
  4 version
  4 locktime
 32 hash(outpoints)
 32 hash(amounts)
 32 hash(sequences)
 32 hash(outputs)
  1 spend_type
 34 scriptPubKey (witness program version (1) + length (1) + pubkey (32))
  4 input index
 32 hash(annex)
---
209 TOTAL
```