### PR TITLE
bip-taproot: fix docstring in taproot_output_script

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -221,8 +221,9 @@ def taproot_output_script(internal_pubkey, script_tree):
     """Given a internal public key and a tree of scripts, compute the output script.
     script_tree is either:
      - a (leaf_version, script) tuple (leaf_version is 0xc0 for bip-tapscript scripts)
-     - a list of two elements, each with the same structure as script_tree itself"""
+     - a list of two elements, each with the same structure as script_tree itself
      - None
+    """
     if script_tree is None:
         h = bytes()
     else:


### PR DESCRIPTION
the final "-None" line in the docstring of `taproot_output_script` example function was actually outside of the docstring