### PR TITLE
bip-taproot: use bytes() instead of b'' - avoid markdown issue

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -224,7 +224,7 @@ def taproot_output_script(internal_pubkey, script_tree):
      - a list of two elements, each with the same structure as script_tree itself"""
      - None
     if script_tree is None:
-        h = b''
+        h = bytes()
     else:
         _, h = taproot_tree_helper(script_tree)
     output_pubkey, _ = taproot_tweak_pubkey(internal_pubkey, h)


### PR DESCRIPTION
Currently github markdown renders `b''` inside `<source>` tags incorrectly. This makes `h = b''` show as `h = b` and creates some confusion.
The issue can be avoided by using bytes() to create empty byte array.
Fixing this way may be beneficial even if github markdown is fixed, because this prevents similar issue with other rendering engines.