### PR TITLE
fix: script spend, not key spend reveals tree depth

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -268,7 +268,7 @@ A key path spend could be a "normal" payment from a single- or multi-signature w
 
 A script path spend leaks that there is a script path and that the key path was not applicable - for example because the involved parties failed to reach agreement.
 Moreover, the depth of a script in the Merkle root leaks information including the minimum depth of the tree, which suggests specific wallet software that created the output and helps clustering.
-Therefore, the privacy of key spends can be improved by deviating from the optimal tree determined by the probability distribution over the leaves.
+Therefore, the privacy of script spends can be improved by deviating from the optimal tree determined by the probability distribution over the leaves.
 
 Just like other existing output types, taproot outputs should never reuse keys.
 This does not only apply to the particular leaf that was used to spend an output but to all leaves committed to in the output.


### PR DESCRIPTION
For the key spend the script tree depth is not revealed, it is only done for script spends. This sentence makes sense only for the script spend.