### PR TITLE
Internal pubkey calculation fixed in taproot_tweak_pubkey()

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -189,7 +189,7 @@ def taproot_tweak_pubkey(pubkey, h):
     t = int_from_bytes(tagged_hash("TapTweak", pubkey + h))
     if t >= SECP256K1_ORDER:
         raise ValueError
-    Q = point_mul(point(pubkey), t)
+    Q = point_add(point(pubkey), point_mul(G, t))
     return bytes_from_int(x(Q)), has_square_y(Q)
 
 def taproot_tweak_seckey(seckey0, h):


### PR DESCRIPTION
Fixes #127 
As suggested by @sipa 