### PR TITLE
Bad pushdata is not the only reason (in theory) GetOp can fail

### DIFF
--- a/bip-tapscript.mediawiki
+++ b/bip-tapscript.mediawiki
@@ -57,7 +57,7 @@ Validation of such inputs must be equivalent to performing the following steps i
 * Since <code>OP_SUCCESSx</code> precedes size check of initial stack and push opcodes, an <code>OP_SUCCESSx</code>-derived opcode requiring stack elements bigger than 520 bytes may uplift the limit in a softfork.
 * <code>OP_SUCCESSx</code> may also redefine the behavior of existing opcodes so they could work together with the new opcode. For example, if an <code>OP_SUCCESSx</code>-derived opcode works with 64-bit integers, it may also allow the existing arithmetic opcodes in the ''same script'' to do the same.
 * Given that <code>OP_SUCCESSx</code> even causes potentially unparseable scripts to pass, it can be used to introduce multi-byte opcodes, or even a completely new scripting language when prefixed with a specific <code>OP_SUCCESSx</code> opcode.</ref>.
-## If any push opcode fails to decode because it would extend past the end of the tapscript, fail.
+## If any opcode fails to decode (for example, because it is a push opcode that would extend past the end of the tapscript), fail.
 # If the '''initial stack''' as defined in bip-taproot (i.e., the witness stack after removing both the optional annex and the two last stack elements after that) violates any resource limits (stack size, and size of the elements in the stack; see "Resource Limits" below), fail. Note that this check can be bypassed using <code>OP_SUCCESSx</code>.
 # The tapscript is executed according to the rules in the following section, with the initial stack as input.
 ## If execution fails for any reason, fail.


### PR DESCRIPTION
It is true that currently, the only reason `ScriptPubKey.GetOp(pc, opcode)` might fail (when `pc` is in bounds) is because the pushdata encoding length extends beyond the script.

But this detail is abstracted away in `GetScriptOp()`, and thus can change independently of the code in `ExecuteWitnessProgram()`.

If an opcode is introduced later that can fail the decoding for other causes, the documentation/implementation introducing this new opcode would need to either to specify explicitly that failing to decode this new opcode has the same effect as bad pushdata in regards to tapscript validation, or change the logic of `ExecuteWitnessProgram()` to distinguish between failing pushdata or this new opcode.

I think it is better to specify that any failed opcode decoding (before `OP_SUCCESSx`) is encountered should mean 'fail', and the specific reason (bad pushdata, indeed the only possible reason currently) to be given as example.