### PR TITLE
ADD: Require BIPs for Taproot and Tapscript

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -9,7 +9,7 @@
   Type: Standards Track
   Created:
   License: BSD-3-Clause
-  Requires: BIP-Schnorr
+  Requires: bip-schnorr
 </pre>
 
 ==Introduction==

--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -9,6 +9,7 @@
   Type: Standards Track
   Created:
   License: BSD-3-Clause
+  Requires: BIP-Schnorr
 </pre>
 
 ==Introduction==

--- a/bip-tapscript.mediawiki
+++ b/bip-tapscript.mediawiki
@@ -9,7 +9,7 @@
   Type: Standards Track
   Created:
   License: BSD-3-Clause
-  Requires: BIP-Schnorr, BIP-Taproot
+  Requires: bip-schnorr, bip-taproot
 </pre>
 
 ==Introduction==

--- a/bip-tapscript.mediawiki
+++ b/bip-tapscript.mediawiki
@@ -9,6 +9,7 @@
   Type: Standards Track
   Created:
   License: BSD-3-Clause
+  Requires: BIP-Schnorr, BIP-Taproot
 </pre>
 
 ==Introduction==


### PR DESCRIPTION
Per https://github.com/bitcoin/bips/blob/master/bip-0001.mediawiki:

"BIPs may have a Requires header, indicating the BIP numbers that this BIP depends on"

Given the scope of the Taproot/Schnorr improvements I think it's important to include all mandatory dependencies of Taproot in the BIP's header.

Currently a placeholder to be replaced with actual BIP number if this BIP/Schnorr proceeds further.