### PR TITLE
Add clarification of semantics of 0x00 hash type

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -100,7 +100,7 @@ The following rules apply:
 
 ==== hash_type ====
 
-<code>hash_type</code> is an 8-bit unsigned value. The <code>SIGHASH</code> encodings from the legacy script system are used, including <code>SIGHASH_ALL</code>, <code>SIGHASH_NONE</code>, <code>SIGHASH_SINGLE</code>, and <code>SIGHASH_ANYONECANPAY</code>
+<code>hash_type</code> is an 8-bit unsigned value. The <code>SIGHASH</code> encodings from the legacy script system are used, including <code>SIGHASH_ALL</code>, <code>SIGHASH_NONE</code>, <code>SIGHASH_SINGLE</code>, and <code>SIGHASH_ANYONECANPAY</code>. Use of the default <code>hash_type = 0x00</code> results in signing over the whole transaction just as for <code>SIGHASH_ALL</code>.
 
 The following use of <code>hash_type</code> are invalid, and fail execution:
 


### PR DESCRIPTION
Opening this because when I read through the BIP with my study group, I (and the others in the group too) did not find myself assuming what is perhaps obvious - that `0x00` results in the same digest semantics as `0x01`, and the reason I did not is exactly because the old flags are retained, including `SIGHASH_ALL = 0x01` and I immediately rejected the possibility that they would have the *same* meaning for the sighashing algo.

I realise that strictly this point is implied by the following "Transaction Data" section, because there is no reference there to ALL or the new 0x00, i.e. both will result in default processing. But I think there's a natural stumbling point here that may confuse implementers and similar when they read through it.

Exact wording please do feel free to alter, it's just a suggestion that seems natural enough.