### PR TITLE
 bip-taproot: clarify bip-schnorr reference code

### DIFF
--- a/bip-taproot.mediawiki
+++ b/bip-taproot.mediawiki
@@ -176,7 +176,7 @@ Alice will not be able to notice the script path, but Mallory can unilaterally s
 </ref>
 * The remaining scripts should be organized into the leaves of a binary tree. This can be a balanced tree if each of the conditions these scripts correspond to are equally likely. If probabilities for each condition are known, consider constructing the tree as a Huffman tree.
 
-'''Computing the output script''' Once the spending conditions are split into an internal key <code>internal_pubkey</code> and a binary tree whose leaves are (leaf_version, script) tuples, the output script can be computed using the following Python3 algorithms with helper functions from the bip-schnorr reference code for integer conversion, point multiplication and tagged hashes.
+'''Computing the output script''' Once the spending conditions are split into an internal key <code>internal_pubkey</code> and a binary tree whose leaves are (leaf_version, script) tuples, the output script can be computed using the Python3 algorithms below. These algorithms take advantage of helper functions from the [https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr/reference.py bip-schnorr reference code] for integer conversion, point multiplication, and tagged hashes.
 
 First, we define <code>taproot_tweak_pubkey</code> for 32-byte bip-schnorr public key arrays.
 In addition to the tweaked public key byte array, the function returns a boolean for the squareness of the tweaked points' Y coordinate modulo the secp256k1 field order.


### PR DESCRIPTION
as per the discussion from http://www.erisian.com.au/taproot-bip-review/log-2019-11-12.html#l-120:

- update the paragraph in question to more clearly convey that the helper
  functions, and not the Python3 example code, are from the bip-schnorr
  reference code

- add a link to the reference code in
  https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr/reference.py
