### PR TITLE
Add debug print for intermediate values 

### DIFF
--- a/bip-0340.mediawiki
+++ b/bip-0340.mediawiki
@@ -136,9 +136,9 @@ Input:
 * The secret key ''sk'': a 32-byte array, freshly generated uniformly at random
 
 The algorithm ''PubKey(sk)'' is defined as:
-* Let ''d = int(sk)''.
-* Fail if ''d = 0'' or ''d &ge; n''.
-* Return ''bytes(d⋅G)''.
+* Let ''d' = int(sk)''.
+* Fail if ''d' = 0'' or ''d' &ge; n''.
+* Return ''bytes(d'⋅G)''.
 
 Note that we use a very different public key format (32 bytes) than the ones used by existing systems (which typically use elliptic curve points as public keys, or 33-byte or 65-byte encodings of them). A side effect is that ''PubKey(sk) = PubKey(bytes(n - int(sk))'', so every public key has two corresponding secret keys.
 

--- a/bip-0340/reference.py
+++ b/bip-0340/reference.py
@@ -33,13 +33,13 @@ def y(P):
     return P[1]
 
 def point_add(P1, P2):
-    if (P1 is None):
+    if P1 is None:
         return P2
-    if (P2 is None):
+    if P2 is None:
         return P1
-    if (x(P1) == x(P2) and y(P1) != y(P2)):
+    if (x(P1) == x(P2)) and (y(P1) != y(P2)):
         return None
-    if (P1 == P2):
+    if P1 == P2:
         lam = (3 * x(P1) * x(P1) * pow(2 * y(P1), p - 2, p)) % p
     else:
         lam = ((y(P2) - y(P1)) * pow(x(P2) - x(P1), p - 2, p)) % p
@@ -49,7 +49,7 @@ def point_add(P1, P2):
 def point_mul(P, n):
     R = None
     for i in range(256):
-        if ((n >> i) & 1):
+        if (n >> i) & 1:
             R = point_add(R, P)
         P = point_add(P, P)
     return R
@@ -90,7 +90,7 @@ def is_square(x):
     return pow(x, (p - 1) // 2, p) == 1
 
 def has_square_y(P):
-    return not is_infinity(P) and is_square(y(P))
+    return (not is_infinity(P)) and (is_square(y(P)))
 
 def has_even_y(P):
     return y(P) % 2 == 0
@@ -144,7 +144,7 @@ def schnorr_verify(msg, pubkey, sig):
         return False
     e = int_from_bytes(tagged_hash("BIP340/challenge", sig[0:32] + pubkey + msg)) % n
     R = point_add(point_mul(G, s), point_mul(P, n - e))
-    if R is None or not has_square_y(R) or x(R) != r:
+    if (R is None) or (not has_square_y(R)) or (x(R) != r):
         debug_print_vars()
         return False
     debug_print_vars()
@@ -168,7 +168,7 @@ def test_vectors():
             msg = bytes.fromhex(msg)
             sig = bytes.fromhex(sig)
             result = result == 'TRUE'
-            print('\nTest vector #%-3i: ' % int(index))
+            print('\nTest vector', ('#' + index).rjust(3, ' ') + ':')
             if seckey != '':
                 seckey = bytes.fromhex(seckey)
                 pubkey_actual = pubkey_gen(seckey)

--- a/bip-0340/reference.py
+++ b/bip-0340/reference.py
@@ -122,7 +122,7 @@ def schnorr_sign(msg, seckey, aux_rand):
     sig = bytes_from_point(R) + bytes_from_int((k + e * d) % n)
     debug_print_vars()
     if not schnorr_verify(msg, bytes_from_point(P), sig):
-        raise RuntimeError('The signature does not pass verification.')
+        raise RuntimeError('The created signature does not pass verification.')
     return sig
 
 def schnorr_verify(msg, pubkey, sig):
@@ -173,13 +173,17 @@ def test_vectors():
                     print('   Expected key:', pubkey.hex().upper())
                     print('     Actual key:', pubkey_actual.hex().upper())
                 aux_rand = bytes.fromhex(aux_rand)
-                sig_actual = schnorr_sign(msg, seckey, aux_rand)
-                if sig == sig_actual:
-                    print(' * Passed signing test.')
-                else:
-                    print(' * Failed signing test.')
-                    print('   Expected signature:', sig.hex().upper())
-                    print('     Actual signature:', sig_actual.hex().upper())
+                try:
+                    sig_actual = schnorr_sign(msg, seckey, aux_rand)
+                    if sig == sig_actual:
+                        print(' * Passed signing test.')
+                    else:
+                        print(' * Failed signing test.')
+                        print('   Expected signature:', sig.hex().upper())
+                        print('     Actual signature:', sig_actual.hex().upper())
+                        all_passed = False
+                except RuntimeError as e:
+                    print(' * Signing test raised exception:', e)
                     all_passed = False
             result_actual = schnorr_verify(msg, pubkey, sig)
             if result == result_actual:

--- a/bip-0340/test-vectors.py
+++ b/bip-0340/test-vectors.py
@@ -15,7 +15,7 @@ def vector0():
     P = point_mul(G, x)
     assert(y(P) % 2 == 0)
 
-    # For historic reasons (pubkey tiebreaker was squareness and not evenness)
+    # For historical reasons (pubkey tiebreaker was squareness and not evenness)
     # we should have at least one test vector where the the point reconstructed
     # from the public key has a square and one where it has a non-square Y
     # coordinate. In this one Y is non-square.


### PR DESCRIPTION
solves https://github.com/sipa/bips/issues/188

Tell me if I overdid it. But I think it's still readable, in particular if you have syntax highlighting and the comments are displayed differently.

This also adjusts the variables to match the BIP text. 

I should have based this on top of #196, sorry. Let's first get #196 merged and I can rebase. 